### PR TITLE
[Contextual Cursor] Fix custom cursors being cleared

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,23 +6,24 @@ repositories {
 	mavenLocal()
 	maven {
 		url = 'https://repo.runelite.net'
+		content {
+			includeGroupByRegex("net\\.runelite.*")
+		}
 	}
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.8.30'
+def runeLiteVersion = 'latest.release'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion
 
-	compileOnly 'org.projectlombok:lombok:1.18.4'
-	annotationProcessor 'org.projectlombok:lombok:1.18.4'
+	compileOnly 'org.projectlombok:lombok:1.18.30'
+	annotationProcessor 'org.projectlombok:lombok:1.18.30'
 
 	testImplementation 'junit:junit:4.12'
-	testImplementation 'org.slf4j:slf4j-simple:1.7.12'
-	testImplementation group: 'net.runelite', name:'client', version: runeLiteVersion, {
-		exclude group: 'ch.qos.logback', module: 'logback-classic'
-	}
+	testImplementation group: 'net.runelite', name:'client', version: runeLiteVersion
+	testImplementation group: 'net.runelite', name:'jshell', version: runeLiteVersion
 }
 
 group = 'io.hydrox.contextualcursor'
@@ -31,4 +32,5 @@ sourceCompatibility = '1.8'
 
 tasks.withType(JavaCompile) {
 	options.encoding = 'UTF-8'
+	options.release.set(11)
 }

--- a/src/main/java/io/hydrox/contextualcursor/ContextualCursorWorkerOverlay.java
+++ b/src/main/java/io/hydrox/contextualcursor/ContextualCursorWorkerOverlay.java
@@ -103,20 +103,10 @@ public class ContextualCursorWorkerOverlay extends Overlay
 		{
 			return;
 		}
-		try
+		final Cursor currentCursor = clientUI.getCurrentCursor();
+		if (!currentCursor.getName().equals("blank"))
 		{
-			// All this because clientUI doesn't have a `getCursor` function.
-			Field f = clientUI.getClass().getDeclaredField("container");
-			f.setAccessible(true);
-			JPanel container = (JPanel) f.get(clientUI);
-			final Cursor currentCursor = container.getCursor();
-			if (!currentCursor.getName().equals("blank"))
-			{
-				originalCursor = container.getCursor();
-			}
-		}
-		catch (NoSuchFieldException | IllegalAccessException ignored)
-		{
+			originalCursor = clientUI.getCurrentCursor();
 		}
 	}
 


### PR DESCRIPTION
Fixes #109

Switch to the official getCurrentCursor function, looks like the old field was removed/changed so restoring the original cursor stopped working at some point. Using getCurrentCursor now properly saves and restores the original cursor.

I also had to update the build.gradle to get it to run, I just copied from the hub plugin template. Let me know if there's something that should be reverted there