### PR TITLE
[Crate Limiter] Fix not limiting items due to wrong Item ID

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.10.8.3'
+def runeLiteVersion = 'latest.release'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ dependencies {
 }
 
 group = 'io.hydrox.cratelimit'
-version = '1.2'
+version = '1.2.1'
 sourceCompatibility = '1.8'
 
 tasks.withType(JavaCompile) {

--- a/runelite-plugin.properties
+++ b/runelite-plugin.properties
@@ -2,5 +2,5 @@ displayName=Crate Limiter
 author=Enriath
 support=https://github.com/Enriath/external-plugins/tree/crate-limiter
 description=Slows down the opening of crates and jars
-tags=crate,jar,eclectic,medium,mediums,rangers,ranger,clue,clues,open,loot
+tags=crate,jar,eclectic,medium,mediums,rangers,ranger,clue,clues,open,loot,nest
 plugins=io.hydrox.cratelimit.CrateLimiterPlugin

--- a/src/main/java/io/hydrox/cratelimit/CrateLimiterPlugin.java
+++ b/src/main/java/io/hydrox/cratelimit/CrateLimiterPlugin.java
@@ -44,7 +44,7 @@ import java.util.Set;
 @PluginDescriptor(
 	name = "Crate Limiter",
 	description = "Slows down the opening of crates and jars",
-	tags = {"crate", "jar", "eclectic", "medium", "mediums", "rangers", "ranger", "clue", "clues", "open", "loot"}
+	tags = {"crate", "jar", "eclectic", "medium", "mediums", "rangers", "ranger", "clue", "clues", "open", "loot", "nest"}
 )
 public class CrateLimiterPlugin extends Plugin
 {

--- a/src/main/java/io/hydrox/cratelimit/CrateLimiterPlugin.java
+++ b/src/main/java/io/hydrox/cratelimit/CrateLimiterPlugin.java
@@ -29,9 +29,9 @@ import com.google.inject.Provides;
 import net.runelite.api.ChatMessageType;
 import net.runelite.api.Client;
 import net.runelite.api.ItemComposition;
-import net.runelite.api.ItemID;
 import net.runelite.api.MenuAction;
 import net.runelite.api.events.MenuOptionClicked;
+import net.runelite.api.gameval.ItemID;
 import net.runelite.client.chat.ChatMessageManager;
 import net.runelite.client.chat.QueuedMessage;
 import net.runelite.client.config.ConfigManager;
@@ -51,34 +51,35 @@ public class CrateLimiterPlugin extends Plugin
 	// These items have an Open option, but shouldn't have a speed limit
 	private static final Set<Integer> OPEN_EXCEPTIONS = ImmutableSet.of(
 		ItemID.LOOTING_BAG,
-		ItemID.HERB_SACK,
+		ItemID.SLAYER_HERB_SACK,
 		ItemID.SEED_BOX,
-		ItemID.BOLT_POUCH,
+		ItemID.XBOWS_BOLT_POUCH,
 		ItemID.COAL_BAG,
 		ItemID.GEM_BAG,
-		ItemID.HUNTER_KIT,
-		ItemID.RUNE_POUCH,
-		ItemID.RUNE_POUCH_L,
-		ItemID.MASTER_SCROLL_BOOK,
-		ItemID.MASTER_SCROLL_BOOK_EMPTY
+		ItemID.DREAM_HUNTER_BOX,
+		ItemID.BH_RUNE_POUCH,
+		ItemID.BH_RUNE_POUCH_TROUVER,
+		ItemID.BOOKOFSCROLLS_CHARGED,
+		ItemID.BOOKOFSCROLLS_EMPTY
 	);
 
 	private static final Set<Integer> BIRD_NESTS = ImmutableSet.of(
-		// Eggs
-		ItemID.BIRD_NEST,
-		ItemID.BIRD_NEST_5071,
-		ItemID.BIRD_NEST_5072,
-		// Old seed nest
-		ItemID.BIRD_NEST_5073,
-		// Rings
-		ItemID.BIRD_NEST_5074,
-		// Old Wyson seed nest
-		ItemID.BIRD_NEST_7413,
-		// Slightly less old Wyson seed nest
-		ItemID.BIRD_NEST_13653,
-		// Modern seed nests
-		ItemID.BIRD_NEST_22798,
-		ItemID.BIRD_NEST_22800
+		// Bird nests with god eggs
+		ItemID.BIRD_NEST_EGG_RED,
+		ItemID.BIRD_NEST_EGG_GREEN,
+		ItemID.BIRD_NEST_EGG_BLUE,
+		// Old bird nest with seeds (Before farming guild update, still able to be found within banks/inv)
+		ItemID.BIRD_NEST_SEEDS,
+		// Bird nests with rings
+		ItemID.BIRD_NEST_RING,
+		// Old bird nests with seeds from Wyson (Before buff on 18 Feb 2016, still able to be found within banks/inv)
+		ItemID.BIRD_NEST_CHEAPSEEDS,
+		// Slightly less old bird nests with seeds from Wyson (After buff but before farming guild update, still able to be found within banks/inv)
+		ItemID.BIRD_NEST_DECENTSEEDS,
+		// Current bird nest with seeds
+		ItemID.BIRD_NEST_SEEDS_JAN2019,
+		// Current bird nest with seeds from Wyson
+		ItemID.BIRD_NEST_DECENTSEEDS_JAN2019
 	);
 
 	@Inject
@@ -108,7 +109,7 @@ public class CrateLimiterPlugin extends Plugin
 		// Seed Pack
 		if (event.getMenuOption().equals("Take"))
 		{
-			if (event.getId() != ItemID.SEED_PACK)
+			if (event.getId() != ItemID.SEEDBOX)
 			{
 				return;
 			}

--- a/src/main/java/io/hydrox/cratelimit/CrateLimiterPlugin.java
+++ b/src/main/java/io/hydrox/cratelimit/CrateLimiterPlugin.java
@@ -102,14 +102,14 @@ public class CrateLimiterPlugin extends Plugin
 	@Subscribe
 	void onMenuOptionClicked(MenuOptionClicked event)
 	{
-		if (event.getMenuAction() != MenuAction.CC_OP)
+		if (event.getMenuAction() != MenuAction.CC_OP && !event.isItemOp())
 		{
 			return;
 		}
 		// Seed Pack
 		if (event.getMenuOption().equals("Take"))
 		{
-			if (event.getId() != ItemID.SEEDBOX)
+			if (event.getItemId() != ItemID.SEEDBOX)
 			{
 				return;
 			}
@@ -117,18 +117,18 @@ public class CrateLimiterPlugin extends Plugin
 		// Nests
 		else if (event.getMenuOption().equals("Search"))
 		{
-			if (!BIRD_NESTS.contains(event.getId()))
+			if (!BIRD_NESTS.contains(event.getItemId()))
 			{
 				return;
 			}
 		}
 		else if (event.getMenuOption().equals("Open"))
 		{
-			if (OPEN_EXCEPTIONS.contains(event.getId()))
+			if (OPEN_EXCEPTIONS.contains(event.getItemId()))
 			{
 				return;
 			}
-			ItemComposition comp = client.getItemDefinition(event.getId());
+			ItemComposition comp = client.getItemDefinition(event.getItemId());
 			// Bundle packs
 			if (comp.getName().endsWith(" pack"))
 			{


### PR DESCRIPTION
This PR fixes an issue where the `MenuOptionClicked` event wouldn't be consumed for item ops which caused the plugin to not function properly. For example, prior to these changes, players could spam click `Search` on Bird nests and this plugin wouldn't limit it according to the set `Ticks per item` config option. After these changes, the plugin behaves as intended.

The main fix to use the appropriate item ID was simple. A while back, RL added item-related methods to `MenuOptionClicked` and `MenuEntry` such as `#getItemId`. If we don't use this method, then `getId` would be returning the wrong ID.

Additional changes:

- Updated the RuneLite version to `latest.release`
    - To use latest available RL API(s) such as the `gameval` API
- Migrated the old usage of ItemID variables to the new gameval API
    - RuneLite's old ItemID API was deprecated
-  Added "nest" to the plugin tags and also its plugin hub tags
- Updated the plugin to v1.2.1